### PR TITLE
Add test cases for PhoneMetadata::writeExternal (#25)

### DIFF
--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -4,6 +4,19 @@
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
   <version>8.12.44-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+  </dependencies>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/Phonemetadata.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/Phonemetadata.java
@@ -863,6 +863,7 @@ public final class Phonemetadata {
     }
 
     public void writeExternal(ObjectOutput objectOutput) throws IOException {
+      // entire method untested
       objectOutput.writeBoolean(hasGeneralDesc);
       if (hasGeneralDesc) {
         generalDesc_.writeExternal(objectOutput);

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/MetadataManagerTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/MetadataManagerTest.java
@@ -17,8 +17,13 @@
 package com.google.i18n.phonenumbers;
 
 import com.google.i18n.phonenumbers.Phonemetadata.PhoneMetadata;
+
+import java.io.*;
+import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import junit.framework.TestCase;
+
+
 
 /**
  * Some basic tests to check that metadata can be correctly loaded.
@@ -83,6 +88,200 @@ public class MetadataManagerTest extends TestCase {
       fail("expected exception");
     } catch (RuntimeException e) {
       assertTrue("Unexpected error: " + e, e.getMessage().contains("no/such/file_123"));
+    }
+  }
+
+  // This test tests compatibility between writeExternal and readExternal
+  // These are used in conjunction to store/load objects from a stream (e.g. a file)
+  // For it to pass any mistakes in writeExternal would have to be in readExternal, too
+  // To test it, multiple significantly different PhoneMetadata objects are stored/loaded
+  public void testWriteExternalEmptyPhoneMetadataCanBeRead() {
+
+    PhoneMetadata pm1 = new PhoneMetadata();
+    try {
+      ByteArrayOutputStream buffer1 = new ByteArrayOutputStream();
+
+      ObjectOutput out1 = new ObjectOutputStream(buffer1);
+
+      pm1.writeExternal(out1);
+      out1.close();
+
+      ByteArrayInputStream buffer2 = new ByteArrayInputStream(buffer1.toByteArray());
+      ObjectInput in = new ObjectInputStream(buffer2);
+      PhoneMetadata pm2 = new PhoneMetadata();
+      pm2.readExternal(in);
+      in.close();
+
+      ByteArrayOutputStream buffer3 = new ByteArrayOutputStream();
+      ObjectOutput out2 = new ObjectOutputStream(buffer3);
+
+      pm2.writeExternal(out2);
+      out2.close();
+
+      byte[] output1 = buffer1.toByteArray();
+      byte[] output2 = buffer3.toByteArray();
+
+      assertTrue(Arrays.equals(output1, output2));
+
+    } catch (Exception e) {
+      fail("Did not expect exception..." + e);
+    }
+  }
+
+  public void testWriteExternalOnShortNumberMetadataCanBeRead() {
+
+    PhoneMetadata pm1 = MetadataManager.getShortNumberMetadataForRegion("US");
+
+    try {
+      ByteArrayOutputStream buffer1 = new ByteArrayOutputStream();
+
+      ObjectOutput out1 = new ObjectOutputStream(buffer1);
+
+      pm1.writeExternal(out1);
+      out1.close();
+
+      ByteArrayInputStream buffer2 = new ByteArrayInputStream(buffer1.toByteArray());
+      ObjectInput in = new ObjectInputStream(buffer2);
+      PhoneMetadata pm2 = new PhoneMetadata();
+      pm2.readExternal(in);
+      in.close();
+
+      ByteArrayOutputStream buffer3 = new ByteArrayOutputStream();
+      ObjectOutput out2 = new ObjectOutputStream(buffer3);
+
+      pm2.writeExternal(out2);
+      out2.close();
+
+      byte[] output1 = buffer1.toByteArray();
+      byte[] output2 = buffer3.toByteArray();
+
+      // assert that writeExternal and readExternal are compatible
+      assertTrue(Arrays.equals(output1, output2));
+
+    } catch (Exception e) {
+      fail("Did not expect exception..." + e);
+    }
+  }
+
+  public void testWriteExternalOnTypicalMetadataCanBeRead() {
+    ConcurrentHashMap<String, PhoneMetadata> map = new ConcurrentHashMap<String, PhoneMetadata>();
+    PhoneMetadata pm1 = MetadataManager.getMetadataFromMultiFilePrefix("CA", map,
+            "/com/google/i18n/phonenumbers/data/PhoneNumberMetadataProtoForTesting",
+            MetadataManager.DEFAULT_METADATA_LOADER);
+    try {
+      ByteArrayOutputStream buffer1 = new ByteArrayOutputStream();
+
+      ObjectOutput out1 = new ObjectOutputStream(buffer1);
+
+      pm1.writeExternal(out1);
+      out1.close();
+
+      ByteArrayInputStream buffer2 = new ByteArrayInputStream(buffer1.toByteArray());
+      ObjectInput in = new ObjectInputStream(buffer2);
+      PhoneMetadata pm2 = new PhoneMetadata();
+      pm2.readExternal(in);
+      in.close();
+
+      ByteArrayOutputStream buffer3 = new ByteArrayOutputStream();
+      ObjectOutput out2 = new ObjectOutputStream(buffer3);
+
+      pm2.writeExternal(out2);
+      out2.close();
+
+      byte[] output1 = buffer1.toByteArray();
+      byte[] output2 = buffer3.toByteArray();
+
+      // assert that writeExternal and readExternal are compatible
+      assertTrue(Arrays.equals(output1, output2));
+
+    } catch (Exception e) {
+      fail("Did not expect exception..." + e);
+    }
+  }
+
+  public void testWriteExternalOnNonTypicalMetadataCanBeRead() {
+    MultiFileMetadataSourceImpl source =
+            new MultiFileMetadataSourceImpl(MetadataManager.DEFAULT_METADATA_LOADER);
+    PhoneMetadata pm1 = source.getMetadataForNonGeographicalRegion(800);
+
+    try {
+      ByteArrayOutputStream buffer1 = new ByteArrayOutputStream();
+
+      ObjectOutput out1 = new ObjectOutputStream(buffer1);
+
+      pm1.writeExternal(out1);
+      out1.close();
+
+      ByteArrayInputStream buffer2 = new ByteArrayInputStream(buffer1.toByteArray());
+      ObjectInput in = new ObjectInputStream(buffer2);
+      PhoneMetadata pm2 = new PhoneMetadata();
+      pm2.readExternal(in);
+      in.close();
+
+      ByteArrayOutputStream buffer3 = new ByteArrayOutputStream();
+      ObjectOutput out2 = new ObjectOutputStream(buffer3);
+
+      pm2.writeExternal(out2);
+      out2.close();
+
+      byte[] output1 = buffer1.toByteArray();
+      byte[] output2 = buffer3.toByteArray();
+
+      // assert that writeExternal and readExternal are compatible
+      assertTrue(Arrays.equals(output1, output2));
+
+    } catch (Exception e) {
+      fail("Did not expect exception..." + e);
+    }
+  }
+
+  public void testWriteExternalOnDetailedMetadataCanBeReadAndHasRightProperties() {
+
+    ConcurrentHashMap<String, PhoneMetadata> map = new ConcurrentHashMap<String, PhoneMetadata>();
+    PhoneMetadata pm1 = MetadataManager.getMetadataFromMultiFilePrefix("US", map,
+            "/com/google/i18n/phonenumbers/data/PhoneNumberMetadataProtoForTesting",
+            MetadataManager.DEFAULT_METADATA_LOADER);
+
+    // Some properties are sampled, and it is asserted that they are written when calling writeExternal
+    pm1.setInternationalPrefix("001");
+    pm1.setPreferredInternationalPrefix("002");
+    pm1.setNationalPrefixTransformRule("5$15");
+    pm1.setLeadingDigits("000");
+
+    try {
+      ByteArrayOutputStream buffer1 = new ByteArrayOutputStream();
+
+      ObjectOutput out1 = new ObjectOutputStream(buffer1);
+
+      pm1.writeExternal(out1);
+      out1.close();
+
+      ByteArrayInputStream buffer2 = new ByteArrayInputStream(buffer1.toByteArray());
+      ObjectInput in = new ObjectInputStream(buffer2);
+      PhoneMetadata pm2 = new PhoneMetadata();
+      pm2.readExternal(in);
+      in.close();
+
+      ByteArrayOutputStream buffer3 = new ByteArrayOutputStream();
+      ObjectOutput out2 = new ObjectOutputStream(buffer3);
+
+      pm2.writeExternal(out2);
+      out2.close();
+
+      byte[] output1 = buffer1.toByteArray();
+      byte[] output2 = buffer3.toByteArray();
+
+      // assert that writeExternal and readExternal are compatible
+      assertTrue(Arrays.equals(output1, output2));
+
+      // assert that some properties are written when using writeExternal
+      assertTrue(pm2.getInternationalPrefix().equals(pm1.getInternationalPrefix()));
+      assertTrue(pm2.getPreferredInternationalPrefix().equals(pm1.getPreferredInternationalPrefix()));
+      assertTrue(pm2.getNationalPrefixTransformRule().equals(pm1.getNationalPrefixTransformRule()));
+      assertTrue(pm2.getLeadingDigits().equals(pm1.getLeadingDigits()));
+
+    } catch (Exception e) {
+      fail("Did not expect exception..." + e);
     }
   }
 }


### PR DESCRIPTION
The test cases improve branch coverage.
The method was previously untested.
Branch coverage improved from 0/0 to 25/25.

The test cases test the requirement that
writeExternal and readExternal are compatible
with each other.

Closes #25 