### PR TITLE
Add test cases for PhoneMetadata.NumberFormat::writeExternal (#26)

### DIFF
--- a/java/libphonenumber/pom.xml
+++ b/java/libphonenumber/pom.xml
@@ -4,6 +4,19 @@
   <groupId>com.googlecode.libphonenumber</groupId>
   <artifactId>libphonenumber</artifactId>
   <version>8.12.44-SNAPSHOT</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.3.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+  </dependencies>
   <packaging>jar</packaging>
   <url>https://github.com/google/libphonenumber/</url>
 

--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/Phonemetadata.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/Phonemetadata.java
@@ -159,23 +159,32 @@ public final class Phonemetadata {
     }
 
     public void writeExternal(ObjectOutput objectOutput) throws IOException {
+      // entire method untested
       objectOutput.writeUTF(pattern_);
       objectOutput.writeUTF(format_);
       int leadingDigitsPatternSize = leadingDigitsPatternSize();
       objectOutput.writeInt(leadingDigitsPatternSize);
+
+      // untested: 0 < leadingDigitsPatternSize and 0 >= leadingDigitsPatternSize
+      // can test with ::getLeadingDigitsPatternCount()
       for (int i = 0; i < leadingDigitsPatternSize; i++) {
         objectOutput.writeUTF(leadingDigitsPattern_.get(i));
       }
 
       objectOutput.writeBoolean(hasNationalPrefixFormattingRule);
+      // untested: hasNationalPrefixFormattingRule and !hasNationalPrefixFormattingRule
+      // can test with ::getNationalPrefixFormattingRule()
       if (hasNationalPrefixFormattingRule) {
         objectOutput.writeUTF(nationalPrefixFormattingRule_);
       }
+
       objectOutput.writeBoolean(hasDomesticCarrierCodeFormattingRule);
+      // untested: hasDomesticCarrierCodeFormattingRule and !hasDomesticCarrierCodeFormattingRule
       if (hasDomesticCarrierCodeFormattingRule) {
         objectOutput.writeUTF(domesticCarrierCodeFormattingRule_);
       }
       objectOutput.writeBoolean(nationalPrefixOptionalWhenFormatting_);
+      // entire method untested
     }
 
     public void readExternal(ObjectInput objectInput) throws IOException {


### PR DESCRIPTION
Test cases to improve branch coverage.
The method was previously untested.
Branch coverage improved from 0/0 to 3/3.

The test cases test the requirement that
writeExternal and readExternal are compatible
with each other.

Closes #26 