### PR TITLE
Add tests for PhoneMetadata.PhoneMetadataCollection::addMetadata (#21)

### DIFF
--- a/java/libphonenumber/src/com/google/i18n/phonenumbers/Phonemetadata.java
+++ b/java/libphonenumber/src/com/google/i18n/phonenumbers/Phonemetadata.java
@@ -1176,9 +1176,11 @@ public final class Phonemetadata {
     public int getMetadataCount() { return metadata_.size(); }
 
     public PhoneMetadataCollection addMetadata(PhoneMetadata value) {
+      // untested: value == null
       if (value == null) {
         throw new NullPointerException();
       }
+      // untested: value != null
       metadata_.add(value);
       return this;
     }

--- a/java/libphonenumber/test/com/google/i18n/phonenumbers/MetadataManagerTest.java
+++ b/java/libphonenumber/test/com/google/i18n/phonenumbers/MetadataManagerTest.java
@@ -85,4 +85,26 @@ public class MetadataManagerTest extends TestCase {
       assertTrue("Unexpected error: " + e, e.getMessage().contains("no/such/file_123"));
     }
   }
+
+  public void testPhoneMetadataCollectionAddMetadata() {
+    MultiFileMetadataSourceImpl source =
+            new MultiFileMetadataSourceImpl(MetadataManager.DEFAULT_METADATA_LOADER);
+
+    PhoneMetadata pm1 = source.getMetadataForRegion("US");
+
+    Phonemetadata.PhoneMetadataCollection pmc = Phonemetadata.PhoneMetadataCollection.newBuilder().addMetadata(pm1);
+
+    assertTrue(reflectionEquals(pm1, pmc.getMetadataList().get(0)));
+
+  }
+
+  public void testPhoneMetadataCollectionAddMetadataNullInput() {
+    try {
+      Phonemetadata.PhoneMetadataCollection pmc = Phonemetadata.PhoneMetadataCollection.newBuilder().addMetadata(null);
+      fail("Expected NullPointerException");
+    } catch (NullPointerException e)
+    {
+      // Expecting NullPointerException
+    }
+  }
 }


### PR DESCRIPTION
Two tests which cover two previously uncovered branches.